### PR TITLE
simpletest in Adafruit new style

### DIFF
--- a/examples/ltr559_simpletest.py
+++ b/examples/ltr559_simpletest.py
@@ -1,0 +1,17 @@
+"""Simple example of the LTR559 library."""
+import time
+import board
+
+from pimoroni_circuitpython_ltr559 import Pimoroni_LTR559
+
+i2c = board.I2C()
+ltr559 = Pimoroni_LTR559(i2c)
+
+# Main loop reading lux and proximity and printing it every second.
+while True:
+    lux = ltr559.lux  # Get Lux value from light sensor
+    prox = ltr559.prox  # Get Proximity value from proximity sensor
+
+    print("Proximity: {0} Lux: {1}".format(prox, lux))
+    # Delay for a second and repeat.
+    time.sleep(1.0)

--- a/examples/ltr559_simpletest.py
+++ b/examples/ltr559_simpletest.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2020 David Glaude
+#
+# SPDX-License-Identifier: Unlicense
 """Simple example of the LTR559 library."""
 import time
 import board


### PR DESCRIPTION
This is a simple test that follow the traditional xxx_simpletest.py format and naming.

Some "improvement":
* plain simple import
* less use of uppercase
* (new) simple access to the default I2C bus from board
* formatted print